### PR TITLE
Fixes Freezing Point Calcs

### DIFF
--- a/scp/base_fluid.py
+++ b/scp/base_fluid.py
@@ -130,6 +130,21 @@ class BaseFluid(ABC):
             return temp
 
     @abstractmethod
+    def freeze_point(self, x: float) -> float:
+        """
+        Abstract method; derived classes shoule override the freezing
+        point of that fluid
+
+        @param x: Fluid concentration fraction, ranging from 0 to 1
+        @return Returns the freezing point of the fluid, in Celsius
+        """
+        pass
+
+    @staticmethod
+    def freeze_point_units() -> str:
+        return "C"
+
+    @abstractmethod
     def viscosity(self, temp: float) -> float:
         """
         Abstract method; derived classes should override to return the dynamic

--- a/scp/cli.py
+++ b/scp/cli.py
@@ -19,6 +19,7 @@ properties = (
     "conductivity",
     "prandtl",
     "thermal_diffusivity",
+    "freeze_point",
 )
 prop_options = click.Choice(properties)
 x_range = click.FloatRange(min=0.0, max=1.0)
@@ -77,9 +78,14 @@ def cli(fluid: str, concentration: float, fluid_prop: str, temperature: float, q
         )
     if fluid == "water" or concentration == 0.0:
         f = water.Water()
+        fluid = "water"
     else:
         f = fluids[fluid](concentration)
-    value = getattr(f, fluid_prop)(temperature)
+
+    if fluid_prop == "freeze_point":
+        value = getattr(f, fluid_prop)(concentration)
+    else:
+        value = getattr(f, fluid_prop)(temperature)
     units = getattr(f, f"{fluid_prop}_units")()
     if quick:
         print(value)

--- a/scp/ethyl_alcohol.py
+++ b/scp/ethyl_alcohol.py
@@ -8,6 +8,16 @@ class EthylAlcohol(BaseMelinder):
     A derived fluid class for ethylene glycol and water mixtures
     """
 
+    def coefficient_freezing(self) -> Tuple:
+        return (
+            (-1.9410e+01, -3.6680e-04, -4.0050e-05, 1.5240e-06),
+            (-9.5400e-01, -1.2090e-05, 2.8770e-06, -4.3940e-08),
+            (-2.6480e-03, -3.1730e-07, 8.6520e-09, -3.7170e-10),
+            (3.8510e-04, 1.3400e-08, -2.0910e-09),
+            (-2.8580e-07, 9.3120e-10),
+            (-1.6700e-07,),
+        )
+
     def coefficient_viscosity(self) -> Tuple:
         return (
             (1.4740e00, -4.7450e-02, 4.3140e-04, -3.0230e-06),
@@ -56,31 +66,9 @@ class EthylAlcohol(BaseMelinder):
         """
 
         super().__init__(0.0, 40, x, 0.0, 0.6)
-        self.t_min = self.t_freeze = self.calc_freeze_point(x)
-
         self.x_base = 29.2361
         self.t_base = 8.1578
-
-    def calc_freeze_point(self, x: float) -> float:
-        """
-        Calculate the freezing point temperature of the mixture
-
-        Based on a curve fit of the Ethyl Alcohol freezing points
-        Engineering Toolbox - https://www.engineeringtoolbox.com/ethanol-water-d_989.html
-
-        @param x: Concentration fraction, from 0 to 0.6
-        """
-
-        # should return 0 C for low concentrations
-        if x < 0.05:
-            return 0
-
-        # polynomial fit
-        # t_f = a + b * conc + c * conc**2 + d * conc**3
-        x = self._check_concentration(x)
-        coefficient_freeze = [2.4685e00, -9.8592e-01, 1.6750e-02, -1.8251e-04]
-        c_pow = [x**p for p in range(4)]
-        return sum(i * j for i, j in zip(coefficient_freeze, c_pow))
+        self.t_min = self.t_freeze = self.freeze_point(x)
 
     @property
     def fluid_name(self) -> str:

--- a/scp/ethylene_glycol.py
+++ b/scp/ethylene_glycol.py
@@ -8,6 +8,16 @@ class EthyleneGlycol(BaseMelinder):
     A derived fluid class for ethylene glycol and water mixtures
     """
 
+    def coefficient_freezing(self) -> Tuple:
+        return (
+            (-1.5250e+01, -1.5660e-06, -2.2780e-07, 2.1690e-09),
+            (-8.0800e-01, -1.3390e-06, 2.0470e-08, -2.7170e-11),
+            (-1.3340e-02, 6.3220e-08, 2.3730e-10, -2.1830e-12),
+            (-7.2930e-05, 1.7640e-09, -2.4420e-11),
+            (1.0060e-06, -7.6620e-11),
+            (1.1400e-09,),
+        )
+
     def coefficient_viscosity(self) -> Tuple:
         return (
             (4.7050e-01, -2.5500e-02, 1.7820e-04, -7.6690e-07),
@@ -56,31 +66,9 @@ class EthyleneGlycol(BaseMelinder):
         """
 
         super().__init__(0.0, 100, x, 0.0, 0.6)
-        self.t_min = self.t_freeze = self.calc_freeze_point(x)
-
         self.x_base = 30.8462
         self.t_base = 31.728
-
-    def calc_freeze_point(self, x: float) -> float:
-        """
-        Calculate the freezing point temperature of the mixture
-
-        Based on a curve fit of the Ethylene Glycol freezing points
-        listed in Chapter 31, Table 4 of the ASHRAE Handbook of Fundamentals, 2009
-
-        @param x: Concentration fraction, from 0 to 0.6
-        """
-
-        # should return 0 C for low concentrations
-        if x < 0.05:
-            return 0
-
-        # polynomial fit
-        # t_f = a + b * conc + c * conc**2 + d * conc**3
-        x = self._check_concentration(x)
-        coefficient_freeze = [5.4792e-02, -2.9922e-01, -2.7478e-03, -9.5960e-05]
-        c_pow = [x**p for p in range(4)]
-        return sum(i * j for i, j in zip(coefficient_freeze, c_pow))
+        self.t_min = self.t_freeze = self.freeze_point(x)
 
     @property
     def fluid_name(self) -> str:

--- a/scp/methyl_alcohol.py
+++ b/scp/methyl_alcohol.py
@@ -8,6 +8,16 @@ class MethylAlcohol(BaseMelinder):
     A derived fluid class for methyl alcohol and water mixtures
     """
 
+    def coefficient_freezing(self) -> Tuple:
+        return (
+            (-2.6290e+01, -2.5750e-06, -6.7320e-06, 1.6300e-07),
+            (-1.1870e+00, -1.6090e-05, 3.4200e-07, 5.6870e-10),
+            (-1.2180e-02, 3.8650e-07, 8.7680e-09, -2.0950e-10),
+            (-6.8230e-05, 2.1370e-08, -4.2710e-10),
+            (1.2970e-07, -5.4070e-10),
+            (2.3630e-08,),
+        )
+
     def coefficient_viscosity(self) -> Tuple:
         return (
             (1.1530e00, -3.8660e-02, 2.7790e-04, -1.5430e-06),
@@ -56,29 +66,9 @@ class MethylAlcohol(BaseMelinder):
         """
 
         super().__init__(0.0, 40.0, x, 0.0, 0.6)
-        self.t_min = self.t_freeze = self.calc_freeze_point(x)
-
         self.x_base = 30.5128
         self.t_base = 3.5359
-
-    def calc_freeze_point(self, x: float) -> float:
-        """
-        Calculate the freezing point temperature of the mixture
-
-        Based on a curve fit of the Methyl Alcohol freezing points
-        Engineering Toolbox - https://www.engineeringtoolbox.com/methanol-water-d_987.html
-        """
-
-        # should return 0 C for low concentrations
-        if x < 0.05:
-            return 0
-
-        # polynomial fit
-        # t_f = a + b * conc + c * conc**2 + d * conc**3
-        x = self._check_concentration(x)
-        coefficient_freeze = [6.9312e-01, -5.6953e-01, -1.2817e-02, 4.3210e-05]
-        c_pow = [x**p for p in range(4)]
-        return sum(i * j for i, j in zip(coefficient_freeze, c_pow))
+        self.t_min = self.t_freeze = self.freeze_point(x)
 
     @property
     def fluid_name(self) -> str:

--- a/scp/propylene_glycol.py
+++ b/scp/propylene_glycol.py
@@ -8,6 +8,16 @@ class PropyleneGlycol(BaseMelinder):
     A derived fluid class for propylene glycol and water mixtures
     """
 
+    def coefficient_freezing(self) -> Tuple:
+        return (
+            (-1.3250e+01, -3.8200e-05, 7.8650e-07, -1.7330e-09),
+            (-6.6310e-01, 6.7740e-06, -6.2420e-08, -7.8190e-10),
+            (-1.0940e-02, 5.3320e-08, -4.1690e-09, 3.2880e-11),
+            (-2.2830e-04, -1.1310e-08, 1.9180e-10),
+            (-3.4090e-06, 8.0350e-11),
+            (1.4650e-08,),
+        )
+
     def coefficient_viscosity(self) -> Tuple:
         return (
             (6.8370e-01, -3.0450e-02, 2.5250e-04, -1.3990e-06),
@@ -56,29 +66,9 @@ class PropyleneGlycol(BaseMelinder):
         """
 
         super().__init__(0.0, 100.0, x, 0.0, 0.6)
-        self.t_min = self.t_freeze = self.calc_freeze_point(x)
-
         self.x_base = 30.7031
         self.t_base = 32.7083
-
-    def calc_freeze_point(self, x: float) -> float:
-        """
-        Calculate the freezing point temperature of the mixture
-
-        Based on a curve fit of the Propylene Glycol freezing points
-        listed in Chapter 31, Table 5 of the ASHRAE Handbook of Fundamentals, 2009
-        """
-
-        # should return 0 C for low concentrations
-        if x < 0.05:
-            return 0
-
-        # polynomial fit
-        # t_f = a + b * conc + c * conc**2 + d * conc**3
-        x = self._check_concentration(x)
-        coefficient_freeze = [7.1734e-03, -3.3692e-01, 2.8466e-03, -1.9024e-04]
-        c_pow = [x**p for p in range(4)]
-        return sum(i * j for i, j in zip(coefficient_freeze, c_pow))
+        self.t_min = self.t_freeze = self.freeze_point(x)
 
     @property
     def fluid_name(self) -> str:

--- a/scp/water.py
+++ b/scp/water.py
@@ -74,6 +74,15 @@ class Water(BaseFluid):
             + (temp**4) * acp4
         ) * 1000
 
+    def freeze_point(self, _=None) -> float:
+        """
+        Returns the freezing point temperature of water
+
+        @param _: Unused variable
+        @return Freezing point temperature, in Celsius
+        """
+        return 0.0
+
     def conductivity(self, temp: float) -> float:
         """
         Returns the fluid thermal conductivity for this derived fluid.

--- a/tests/test_ethlylene_glycol.py
+++ b/tests/test_ethlylene_glycol.py
@@ -123,3 +123,22 @@ class TestEthyleneGlycol(TestCase):
 
         # Cond @ T=40degC, X=0.4: 4.4050e-01. Err Tol: 0.1%
         self.assertAlmostEqual(p.conductivity(40), 4.4050e-01, delta=4.4050e-04)
+
+    def test_t_freeze(self):
+        # T_freeze @ X=0.1: -3.357. ErrTol=0.01C
+        self.assertAlmostEqual(EthyleneGlycol(0.1).freeze_point(0.1), -3.357, delta=1.0e-02)
+
+        # T_freeze @ X=0.2: -7.949. ErrTol=0.01C
+        self.assertAlmostEqual(EthyleneGlycol(0.2).freeze_point(0.2), -7.949, delta=1.0e-02)
+
+        # T_freeze @ X=0.3: -14.576. ErrTol=0.01C
+        self.assertAlmostEqual(EthyleneGlycol(0.3).freeze_point(0.3), -14.576, delta=1.0e-02)
+
+        # T_freeze @ X=0.4: -23.813. ErrTol=0.01C
+        self.assertAlmostEqual(EthyleneGlycol(0.4).freeze_point(0.4), -23.813, delta=1.0e-02)
+
+        # T_freeze @ X=0.5: -35.994. ErrTol=0.01C
+        self.assertAlmostEqual(EthyleneGlycol(0.5).freeze_point(0.5), -35.994, delta=1.0e-02)
+
+        # T_freeze @ X=0.6: -51.201. ErrTol=0.01C
+        self.assertAlmostEqual(EthyleneGlycol(0.6).freeze_point(0.6), -51.201, delta=1.0e-02)

--- a/tests/test_ethyl_alcohol.py
+++ b/tests/test_ethyl_alcohol.py
@@ -123,3 +123,22 @@ class TestPropyleneGlycol(TestCase):
 
         # Cond @ T=40degC, X=0.4: 3.6934e-01. Err Tol: 0.1%
         self.assertAlmostEqual(p.conductivity(40), 3.6934e-01, delta=3.6934e-04)
+
+    def test_t_freeze(self):
+        # T_freeze @ X=0.1: -4.379. ErrTol=0.01C
+        self.assertAlmostEqual(EthylAlcohol(0.1).freeze_point(0.1), -4.379, delta=1.0e-02)
+
+        # T_freeze @ X=0.2: -11.119. ErrTol=0.01C
+        self.assertAlmostEqual(EthylAlcohol(0.2).freeze_point(0.2), -11.119, delta=1.0e-02)
+
+        # T_freeze @ X=0.3: -20.140. ErrTol=0.01C
+        self.assertAlmostEqual(EthylAlcohol(0.3).freeze_point(0.3), -20.140, delta=1.0e-02)
+
+        # T_freeze @ X=0.4: -29.533. ErrTol=0.01C
+        self.assertAlmostEqual(EthylAlcohol(0.4).freeze_point(0.4), -29.533, delta=1.0e-02)
+
+        # T_freeze @ X=0.5: -37.611. ErrTol=0.01C
+        self.assertAlmostEqual(EthylAlcohol(0.5).freeze_point(0.5), -37.611, delta=1.0e-02)
+
+        # T_freeze @ X=0.6: -44.910. ErrTol=0.01C
+        self.assertAlmostEqual(EthylAlcohol(0.6).freeze_point(0.6), -44.910, delta=1.0e-02)

--- a/tests/test_methyl_alcohol.py
+++ b/tests/test_methyl_alcohol.py
@@ -123,3 +123,22 @@ class TestMethylAlcohol(TestCase):
 
         # Cond @ T=40degC, X=0.4: 3.9646e-01. Err Tol: 0.1%
         self.assertAlmostEqual(p.conductivity(40), 3.9646e-01, delta=3.9646e-04)
+
+    def test_t_freeze(self):
+        # T_freeze @ X=0.1: -6.540. ErrTol=0.01C
+        self.assertAlmostEqual(MethylAlcohol(0.1).freeze_point(0.1), -6.540, delta=1.0e-02)
+
+        # T_freeze @ X=0.2: -15.080. ErrTol=0.01C
+        self.assertAlmostEqual(MethylAlcohol(0.2).freeze_point(0.2), -15.080, delta=1.0e-02)
+
+        # T_freeze @ X=0.3: -25.685. ErrTol=0.01C
+        self.assertAlmostEqual(MethylAlcohol(0.3).freeze_point(0.3), -25.685, delta=1.0e-02)
+
+        # T_freeze @ X=0.4: -38.703. ErrTol=0.01C
+        self.assertAlmostEqual(MethylAlcohol(0.4).freeze_point(0.4), -38.703, delta=1.0e-02)
+
+        # T_freeze @ X=0.5: -54.466. ErrTol=0.01C
+        self.assertAlmostEqual(MethylAlcohol(0.5).freeze_point(0.5), -54.466, delta=1.0e-02)
+
+        # T_freeze @ X=0.6: -73.006. ErrTol=0.01C
+        self.assertAlmostEqual(MethylAlcohol(0.6).freeze_point(0.6), -73.006, delta=1.0e-02)

--- a/tests/test_propylene_glycol.py
+++ b/tests/test_propylene_glycol.py
@@ -123,3 +123,22 @@ class TestPropyleneGlycol(TestCase):
 
         # Cond @ T=40degC, X=0.4: 4.1321e-01. Err Tol: 0.1%
         self.assertAlmostEqual(p.conductivity(40), 4.1321e-01, delta=4.1321e-04)
+
+    def test_t_freeze(self):
+        # T_freeze @ X=0.1: -2.867. ErrTol=0.01C
+        self.assertAlmostEqual(PropyleneGlycol(0.1).freeze_point(0.1), -2.867, delta=1.0e-02)
+
+        # T_freeze @ X=0.2: -7.173. ErrTol=0.01C
+        self.assertAlmostEqual(PropyleneGlycol(0.2).freeze_point(0.2), -7.173, delta=1.0e-02)
+
+        # T_freeze @ X=0.3: -12.789. ErrTol=0.01C
+        self.assertAlmostEqual(PropyleneGlycol(0.3).freeze_point(0.3), -12.789, delta=1.0e-02)
+
+        # T_freeze @ X=0.4: -20.568. ErrTol=0.01C
+        self.assertAlmostEqual(PropyleneGlycol(0.4).freeze_point(0.4), -20.568, delta=1.0e-02)
+
+        # T_freeze @ X=0.5: -32.193. ErrTol=0.01C
+        self.assertAlmostEqual(PropyleneGlycol(0.5).freeze_point(0.5), -32.193, delta=1.0e-02)
+
+        # T_freeze @ X=0.6: -50.003. ErrTol=0.01C
+        self.assertAlmostEqual(PropyleneGlycol(0.6).freeze_point(0.6), -50.003, delta=1.0e-02)

--- a/tests/test_water.py
+++ b/tests/test_water.py
@@ -120,3 +120,6 @@ class TestWater(TestCase):
 
         # T: 99 [C], ErrTol: 1.0%
         self.assertAlmostEqual(self.p.conductivity(99.0), 6.768e-01, delta=6.768e-03)
+
+    def test_t_freeze(self):
+        self.assertAlmostEqual(Water().freeze_point(), 0.000, delta=1.0e-02)


### PR DESCRIPTION
Previous correlations mistakenly correlated concentration as a percentage instead of as a fraction. This converts it over to use the Melinder freezing point correlations.