### PR TITLE
update tests to run Ubuntu/Windows/Linux for 3.7, 3.8, and 3.9. 3.10 …

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,20 +2,24 @@ name: Run Tests
 
 on: [push]
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
-  unit_tests:
-    runs-on: ubuntu-20.04
+  builds:
+    strategy:
+      matrix:
+        python-version: [ "3.7", "3.8", "3.9" ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version:  ${{ matrix.python-version }}
+
       - name: Install Pip Dependencies
         run: pip install nose coverage
+
       - name: Run Tests
         run: nosetests --with-coverage --cover-package scp  # --cover-html for local html results


### PR DESCRIPTION
Updates to run tests on Linux, Mac, Windows using Python versions 3.7, 3.8, and 3.9. 3.10 fails due to some unrelated errors in the Collections module.