### PR TITLE
Fix Temp Limit Checks Usage on Water

### DIFF
--- a/scp/water.py
+++ b/scp/water.py
@@ -25,7 +25,7 @@ class Water(BaseFluid):
         @return: The dynamic viscosity of water in [Pa-s]
         """
 
-        self._check_temperature(temp)
+        temp = self._check_temperature(temp)
 
         am0 = -3.30233
         am1 = 1301
@@ -40,6 +40,7 @@ class Water(BaseFluid):
         am11 = -0.0059231
         am12 = 2.1249e-05
         am13 = -2.69575e-08
+
         if temp < 20:
             exponent = am0 + am1 / (am2 + (temp - 20) * (am3 + am4 * (temp - 20)))
             return (10**exponent) * 0.1
@@ -58,7 +59,7 @@ class Water(BaseFluid):
         @return: Specific heat, in [J/kg-K]
         """
 
-        self._check_temperature(temp)
+        temp = self._check_temperature(temp)
 
         acp0 = 4.21534
         acp1 = -0.00287819
@@ -93,7 +94,7 @@ class Water(BaseFluid):
         @return: Thermal conductivity, in [W/m-K]
         """
 
-        self._check_temperature(temp)
+        temp = self._check_temperature(temp)
 
         ak0 = 0.560101
         ak1 = 0.00211703
@@ -115,7 +116,7 @@ class Water(BaseFluid):
         @return: Density, in [kg/m3]
         """
 
-        self._check_temperature(temp)
+        temp = self._check_temperature(temp)
 
         ar0 = 999.83952
         ar1 = 16.945176

--- a/tests/test_ethlylene_glycol.py
+++ b/tests/test_ethlylene_glycol.py
@@ -1,3 +1,5 @@
+import pytest
+
 from unittest import TestCase
 
 from scp.ethylene_glycol import EthyleneGlycol
@@ -142,3 +144,9 @@ class TestEthyleneGlycol(TestCase):
 
         # T_freeze @ X=0.6: -51.201. ErrTol=0.01C
         self.assertAlmostEqual(EthyleneGlycol(0.6).freeze_point(0.6), -51.201, delta=1.0e-02)
+
+    @pytest.mark.filterwarnings("ignore::UserWarning")
+    def test_out_of_range_temps(self):
+        p = EthyleneGlycol(0.4)
+        self.assertAlmostEqual(p.density(-50), p.density(p.t_min), delta=0.01)
+        self.assertAlmostEqual(p.density(150), p.density(p.t_max), delta=0.01)

--- a/tests/test_ethyl_alcohol.py
+++ b/tests/test_ethyl_alcohol.py
@@ -1,3 +1,5 @@
+import pytest
+
 from unittest import TestCase
 
 from scp.ethyl_alcohol import EthylAlcohol
@@ -142,3 +144,9 @@ class TestPropyleneGlycol(TestCase):
 
         # T_freeze @ X=0.6: -44.910. ErrTol=0.01C
         self.assertAlmostEqual(EthylAlcohol(0.6).freeze_point(0.6), -44.910, delta=1.0e-02)
+
+    @pytest.mark.filterwarnings("ignore::UserWarning")
+    def test_out_of_range_temps(self):
+        p = EthylAlcohol(0.4)
+        self.assertAlmostEqual(p.density(-50), p.density(p.t_min), delta=0.01)
+        self.assertAlmostEqual(p.density(150), p.density(p.t_max), delta=0.01)

--- a/tests/test_methyl_alcohol.py
+++ b/tests/test_methyl_alcohol.py
@@ -1,3 +1,5 @@
+import pytest
+
 from unittest import TestCase
 
 from scp.methyl_alcohol import MethylAlcohol
@@ -142,3 +144,9 @@ class TestMethylAlcohol(TestCase):
 
         # T_freeze @ X=0.6: -73.006. ErrTol=0.01C
         self.assertAlmostEqual(MethylAlcohol(0.6).freeze_point(0.6), -73.006, delta=1.0e-02)
+
+    @pytest.mark.filterwarnings("ignore::UserWarning")
+    def test_out_of_range_temps(self):
+        p = MethylAlcohol(0.4)
+        self.assertAlmostEqual(p.density(-50), p.density(p.t_min), delta=0.01)
+        self.assertAlmostEqual(p.density(150), p.density(p.t_max), delta=0.01)

--- a/tests/test_propylene_glycol.py
+++ b/tests/test_propylene_glycol.py
@@ -1,3 +1,5 @@
+import pytest
+
 from unittest import TestCase
 
 from scp.propylene_glycol import PropyleneGlycol
@@ -142,3 +144,9 @@ class TestPropyleneGlycol(TestCase):
 
         # T_freeze @ X=0.6: -50.003. ErrTol=0.01C
         self.assertAlmostEqual(PropyleneGlycol(0.6).freeze_point(0.6), -50.003, delta=1.0e-02)
+
+    @pytest.mark.filterwarnings("ignore::UserWarning")
+    def test_out_of_range_temps(self):
+        p = PropyleneGlycol(0.4)
+        self.assertAlmostEqual(p.density(-50), p.density(p.t_min), delta=0.01)
+        self.assertAlmostEqual(p.density(150), p.density(p.t_max), delta=0.01)

--- a/tests/test_water.py
+++ b/tests/test_water.py
@@ -1,3 +1,5 @@
+import pytest
+
 from unittest import TestCase
 
 from scp.water import Water
@@ -123,3 +125,8 @@ class TestWater(TestCase):
 
     def test_t_freeze(self):
         self.assertAlmostEqual(Water().freeze_point(), 0.000, delta=1.0e-02)
+
+    @pytest.mark.filterwarnings("ignore::UserWarning")
+    def test_out_of_range_temps(self):
+        self.assertAlmostEqual(self.p.density(-10), self.p.density(Water().t_min), delta=0.01)
+        self.assertAlmostEqual(self.p.density(110), self.p.density(Water().t_max), delta=0.01)


### PR DESCRIPTION
For water, the temperature value for property evaluation was being passed in and checked against the max/min limits; however, when these conditions were encountered, the temperature used for the subsequent property evaluation was not reset to the respective nearest max/min value. This corrects that error and adds tests to the all supported fluids to verify the proper behavior.

Thanks to @TNWest for catching this.

PR resolves #16 