### PR TITLE
Add User Defined Fluid and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Project page: https://pypi.org/project/SecondaryCoolantProps/
 
 `uv sync`
 
+Use a current `uv` release. This project uses dependency groups and
+`tool.uv.default-groups`, which older `uv` releases may not recognize.
+
 #### Run pre-commit checks:
 
 `uv run pre-commit run -a`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,41 @@
+User-Facing API
+===============
+
+The recommended programmatic interface is the small API exposed from ``scp``.
+It lets applications construct fluids and evaluate properties without importing
+the concrete fluid classes directly.
+
+Examples::
+
+    from scp import get_fluid
+
+    water = get_fluid("water")
+    water_density = water.density(25.0)
+
+    pg = get_fluid("propylene_glycol", concentration=0.4)
+    pg_viscosity = pg.viscosity(20.0)
+
+User-defined fluids can be created through the same API.  The core properties
+can be constants or callables that accept temperature in Celsius::
+
+    from scp import get_fluid
+
+    fluid = get_fluid(
+        "user_defined",
+        name="CustomFluid",
+        viscosity=lambda temp: 0.003 - 1.0e-5 * temp,
+        specific_heat=3200.0,
+        density=lambda temp: 1000.0 - 0.5 * temp,
+        conductivity=0.42,
+        freeze_point=-12.0,
+        t_min=-20.0,
+        t_max=80.0,
+    )
+
+    print(fluid.density(20.0))
+
+.. automodule:: scp.api
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :noindex:

--- a/docs/fluid_ethyl_alcohol.rst
+++ b/docs/fluid_ethyl_alcohol.rst
@@ -1,18 +1,35 @@
-Ethyl Alcohol (Ethylene)
-========================
+Ethyl Alcohol
+=============
 
-Provides fluid properties for aqueous mixtures of Ethylene for temperatures <= 40 C, with concentrations from 0-0.6.
+Provides fluid properties for aqueous mixtures of Ethyl Alcohol for temperatures <= 40 C, with concentrations from 0-0.6.
 
 Example::
 
-    from scp.ethyl_alcohol import MethylAlcohol
+    from scp import get_fluid
 
     if __name__ == "__main__":
-        x_fraction = 0.2  # concentration fraction
-        ea = EthylAlcohol(x_fraction)
+        concentration = 0.2  # mixture concentration fraction
+        ethyl_alcohol = get_fluid("ethyl_alcohol", concentration=concentration)
 
-        temp = 10  # Celsius
-        print(ea.viscosity(temp))
+        temp = 10.0  # Celsius
+        viscosity = ethyl_alcohol.viscosity(temp)
+        density = ethyl_alcohol.density(temp)
+        specific_heat = ethyl_alcohol.specific_heat(temp)
+        conductivity = ethyl_alcohol.conductivity(temp)
+        prandtl = ethyl_alcohol.prandtl(temp)
+        thermal_diffusivity = ethyl_alcohol.thermal_diffusivity(temp)
+        freeze_point = ethyl_alcohol.freeze_point(concentration)
+
+        print(f"Viscosity: {viscosity} {ethyl_alcohol.viscosity_units()}")
+        print(f"Density: {density} {ethyl_alcohol.density_units()}")
+        print(f"Specific heat: {specific_heat} {ethyl_alcohol.specific_heat_units()}")
+        print(f"Conductivity: {conductivity} {ethyl_alcohol.conductivity_units()}")
+        print(f"Prandtl number: {prandtl} {ethyl_alcohol.prandtl_units()}")
+        print(
+            f"Thermal diffusivity: {thermal_diffusivity} "
+            f"{ethyl_alcohol.thermal_diffusivity_units()}"
+        )
+        print(f"Freeze point: {freeze_point} {ethyl_alcohol.freeze_point_units()}")
 
 .. automodule:: scp.ethyl_alcohol
     :members:

--- a/docs/fluid_ethylene_glycol.rst
+++ b/docs/fluid_ethylene_glycol.rst
@@ -5,14 +5,31 @@ Provides fluid properties for aqueous mixtures of Ethylene Glycol for temperatur
 
 Example::
 
-    from scp.ethylene_glycol import EthyleneGlycol
+    from scp import get_fluid
 
     if __name__ == "__main__":
-        x_fraction = 0.2  # concentration fraction
-        eg = EthyleneGlycol(x_fraction)
+        concentration = 0.2  # mixture concentration fraction
+        ethylene_glycol = get_fluid("ethylene_glycol", concentration=concentration)
 
-        temp = 10  # Celsius
-        print(eg.viscosity(temp))
+        temp = 10.0  # Celsius
+        viscosity = ethylene_glycol.viscosity(temp)
+        density = ethylene_glycol.density(temp)
+        specific_heat = ethylene_glycol.specific_heat(temp)
+        conductivity = ethylene_glycol.conductivity(temp)
+        prandtl = ethylene_glycol.prandtl(temp)
+        thermal_diffusivity = ethylene_glycol.thermal_diffusivity(temp)
+        freeze_point = ethylene_glycol.freeze_point(concentration)
+
+        print(f"Viscosity: {viscosity} {ethylene_glycol.viscosity_units()}")
+        print(f"Density: {density} {ethylene_glycol.density_units()}")
+        print(f"Specific heat: {specific_heat} {ethylene_glycol.specific_heat_units()}")
+        print(f"Conductivity: {conductivity} {ethylene_glycol.conductivity_units()}")
+        print(f"Prandtl number: {prandtl} {ethylene_glycol.prandtl_units()}")
+        print(
+            f"Thermal diffusivity: {thermal_diffusivity} "
+            f"{ethylene_glycol.thermal_diffusivity_units()}"
+        )
+        print(f"Freeze point: {freeze_point} {ethylene_glycol.freeze_point_units()}")
 
 .. automodule:: scp.ethylene_glycol
     :members:

--- a/docs/fluid_instances.rst
+++ b/docs/fluid_instances.rst
@@ -11,4 +11,5 @@ Here are the currently supported fluids.
    fluid_ethylene_glycol
    fluid_methyl_alcohol
    fluid_propylene_glycol
+   fluid_user_defined
    fluid_water

--- a/docs/fluid_methyl_alcohol.rst
+++ b/docs/fluid_methyl_alcohol.rst
@@ -1,18 +1,35 @@
-Methyl Alcohol (Methylene)
-==========================
+Methyl Alcohol
+==============
 
-Provides fluid properties for aqueous mixtures of Methylene for temperatures <= 40 C, with concentrations from 0-0.6.
+Provides fluid properties for aqueous mixtures of Methyl Alcohol for temperatures <= 40 C, with concentrations from 0-0.6.
 
 Example::
 
-    from scp.methyl_alcohol import MethylAlcohol
+    from scp import get_fluid
 
     if __name__ == "__main__":
-        x_fraction = 0.2  # concentration fraction
-        ma = MethylAlcohol(x_fraction)
+        concentration = 0.2  # mixture concentration fraction
+        methyl_alcohol = get_fluid("methyl_alcohol", concentration=concentration)
 
-        temp = 10  # Celsius
-        print(ma.viscosity(temp))
+        temp = 10.0  # Celsius
+        viscosity = methyl_alcohol.viscosity(temp)
+        density = methyl_alcohol.density(temp)
+        specific_heat = methyl_alcohol.specific_heat(temp)
+        conductivity = methyl_alcohol.conductivity(temp)
+        prandtl = methyl_alcohol.prandtl(temp)
+        thermal_diffusivity = methyl_alcohol.thermal_diffusivity(temp)
+        freeze_point = methyl_alcohol.freeze_point(concentration)
+
+        print(f"Viscosity: {viscosity} {methyl_alcohol.viscosity_units()}")
+        print(f"Density: {density} {methyl_alcohol.density_units()}")
+        print(f"Specific heat: {specific_heat} {methyl_alcohol.specific_heat_units()}")
+        print(f"Conductivity: {conductivity} {methyl_alcohol.conductivity_units()}")
+        print(f"Prandtl number: {prandtl} {methyl_alcohol.prandtl_units()}")
+        print(
+            f"Thermal diffusivity: {thermal_diffusivity} "
+            f"{methyl_alcohol.thermal_diffusivity_units()}"
+        )
+        print(f"Freeze point: {freeze_point} {methyl_alcohol.freeze_point_units()}")
 
 .. automodule:: scp.methyl_alcohol
     :members:

--- a/docs/fluid_propylene_glycol.rst
+++ b/docs/fluid_propylene_glycol.rst
@@ -1,18 +1,35 @@
 Propylene Glycol
 ================
 
-Provides fluid properties for aqueous mixtures of Propylene Gycol for temperatures <=100 C, with concentrations from 0-0.6.
+Provides fluid properties for aqueous mixtures of Propylene Glycol for temperatures <= 100 C, with concentrations from 0-0.6.
 
 Example::
 
-    from scp.propylene_glycol import PropyleneGycol
+    from scp import get_fluid
 
     if __name__ == "__main__":
-        x_fraction = 0.2  # concentration fraction
-        pg = PropyleneGycol(x_fraction)
+        concentration = 0.2  # mixture concentration fraction
+        propylene_glycol = get_fluid("propylene_glycol", concentration=concentration)
 
-        temp = 10  # Celsius
-        print(pg.viscosity(temp))
+        temp = 10.0  # Celsius
+        viscosity = propylene_glycol.viscosity(temp)
+        density = propylene_glycol.density(temp)
+        specific_heat = propylene_glycol.specific_heat(temp)
+        conductivity = propylene_glycol.conductivity(temp)
+        prandtl = propylene_glycol.prandtl(temp)
+        thermal_diffusivity = propylene_glycol.thermal_diffusivity(temp)
+        freeze_point = propylene_glycol.freeze_point(concentration)
+
+        print(f"Viscosity: {viscosity} {propylene_glycol.viscosity_units()}")
+        print(f"Density: {density} {propylene_glycol.density_units()}")
+        print(f"Specific heat: {specific_heat} {propylene_glycol.specific_heat_units()}")
+        print(f"Conductivity: {conductivity} {propylene_glycol.conductivity_units()}")
+        print(f"Prandtl number: {prandtl} {propylene_glycol.prandtl_units()}")
+        print(
+            f"Thermal diffusivity: {thermal_diffusivity} "
+            f"{propylene_glycol.thermal_diffusivity_units()}"
+        )
+        print(f"Freeze point: {freeze_point} {propylene_glycol.freeze_point_units()}")
 
 .. automodule:: scp.propylene_glycol
     :members:

--- a/docs/fluid_user_defined.rst
+++ b/docs/fluid_user_defined.rst
@@ -1,0 +1,68 @@
+User-Defined Fluid
+==================
+
+Provides a fluid implementation where applications supply the core property
+values directly.  Prefer creating this fluid with ``scp.get_fluid("user_defined", ...)``.
+Viscosity, specific heat, density, and conductivity are required.  Each property
+can be a constant value or a callable that accepts temperature in Celsius.
+Freeze point is optional and defaults to 0 C.
+
+Example with inline property values::
+
+    from scp import get_fluid
+
+    if __name__ == "__main__":
+        custom_fluid = get_fluid(
+            "user_defined",
+            name="CustomFluid",
+            viscosity=lambda temp: 0.003 - 1.0e-5 * temp,
+            specific_heat=3200.0,
+            density=lambda temp: 1000.0 - 0.5 * temp,
+            conductivity=0.42,
+            freeze_point=-12.0,
+            t_min=-20.0,
+            t_max=80.0,
+        )
+
+        temp = 20.0  # Celsius
+        viscosity = custom_fluid.viscosity(temp)
+        density = custom_fluid.density(temp)
+        specific_heat = custom_fluid.specific_heat(temp)
+        conductivity = custom_fluid.conductivity(temp)
+        prandtl = custom_fluid.prandtl(temp)
+        thermal_diffusivity = custom_fluid.thermal_diffusivity(temp)
+        freeze_point = custom_fluid.freeze_point()
+
+        print(f"Viscosity: {viscosity} {custom_fluid.viscosity_units()}")
+        print(f"Density: {density} {custom_fluid.density_units()}")
+        print(f"Specific heat: {specific_heat} {custom_fluid.specific_heat_units()}")
+        print(f"Conductivity: {conductivity} {custom_fluid.conductivity_units()}")
+        print(f"Prandtl number: {prandtl} {custom_fluid.prandtl_units()}")
+        print(f"Thermal diffusivity: {thermal_diffusivity} {custom_fluid.thermal_diffusivity_units()}")
+        print(f"Freeze point: {freeze_point} {custom_fluid.freeze_point_units()}")
+
+Example using a reusable property object::
+
+    from scp import UserDefinedProperties, get_fluid
+
+    properties = UserDefinedProperties(
+        viscosity=0.002,
+        specific_heat=3200.0,
+        density=1050.0,
+        conductivity=0.42,
+        freeze_point=-12.0,
+    )
+
+    custom_fluid = get_fluid(
+        "user_defined",
+        name="CustomFluid",
+        properties=properties,
+        t_min=-20.0,
+        t_max=80.0,
+    )
+
+.. automodule:: scp.user_defined
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :noindex:

--- a/docs/fluid_water.rst
+++ b/docs/fluid_water.rst
@@ -5,12 +5,27 @@ Provides fluid properties for liquid water between 0-100 C.
 
 Example::
 
-    from scp.water import Water
+    from scp import get_fluid
 
     if __name__ == "__main__":
-        water = Water()
-        temp = 10  # Celsius
-        print(water.viscosity(temp))
+        water = get_fluid("water")
+
+        temp = 10.0  # Celsius
+        viscosity = water.viscosity(temp)
+        density = water.density(temp)
+        specific_heat = water.specific_heat(temp)
+        conductivity = water.conductivity(temp)
+        prandtl = water.prandtl(temp)
+        thermal_diffusivity = water.thermal_diffusivity(temp)
+        freeze_point = water.freeze_point()
+
+        print(f"Viscosity: {viscosity} {water.viscosity_units()}")
+        print(f"Density: {density} {water.density_units()}")
+        print(f"Specific heat: {specific_heat} {water.specific_heat_units()}")
+        print(f"Conductivity: {conductivity} {water.conductivity_units()}")
+        print(f"Prandtl number: {prandtl} {water.prandtl_units()}")
+        print(f"Thermal diffusivity: {thermal_diffusivity} {water.thermal_diffusivity_units()}")
+        print(f"Freeze point: {freeze_point} {water.freeze_point_units()}")
 
 .. automodule:: scp.water
     :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Welcome to SecondaryCoolantProps's documentation!
    :caption: Contents:
 
    base_fluids
+   api
    cli
    prog_usage
    fluid_instances

--- a/docs/prog_usage.rst
+++ b/docs/prog_usage.rst
@@ -1,17 +1,17 @@
 Preferred Programmatic Usage
 ============================
 
-For programmatic usage, the preferred approach is for users to directly consume
-the fluid classes directly in your applications. Applications of using the CLI
-approach with ``scprop`` should be limited to that use case.
+For programmatic usage, the preferred approach is the user-facing API exposed
+from ``scp``.  Applications of using the CLI approach with ``scprop`` should be
+limited to that use case.
 
 An example usage::
 
-    from scp.water import Water
+    from scp import get_fluid
 
     class MyClass:
         def __init__(self):
-            self.my_fluid = Water()
+            self.my_fluid = get_fluid("water")
 
         def do_something(self):
             # do some calculations
@@ -25,11 +25,36 @@ An example usage::
             # continue
             # ...
 
-Other fluids can also be imported and applied in a similar fashion.
+Other fluids can also be created through the same function.
 
 Other examples::
 
-    from scp.ethyl_alcohol import EthylAlcohol
-    from scp.ethylene_glycol import EthyleneGlycol
-    from scp.methyl_alcohol import MethylAlcohol
-    from scp.propylene_glycol import PropyleneGlycol
+    from scp import get_fluid
+
+    ethyl_alcohol = get_fluid("ethyl_alcohol", concentration=0.3)
+    ethylene_glycol = get_fluid("ethylene_glycol", concentration=0.3)
+    methyl_alcohol = get_fluid("methyl_alcohol", concentration=0.3)
+    propylene_glycol = get_fluid("propylene_glycol", concentration=0.3)
+
+    water = get_fluid("water")
+    density = water.density(25.0)
+
+User-defined fluid properties can be supplied through the same API.  Constant
+values are accepted, and temperature-dependent values can be callables that
+accept temperature in Celsius::
+
+    from scp import get_fluid
+
+    custom_fluid = get_fluid(
+        "user_defined",
+        name="CustomFluid",
+        viscosity=lambda temp: 0.003 - 1.0e-5 * temp,
+        specific_heat=3200.0,
+        density=lambda temp: 1000.0 - 0.5 * temp,
+        conductivity=0.42,
+        freeze_point=-12.0,
+        t_min=-20.0,
+        t_max=80.0,
+    )
+
+    viscosity = custom_fluid.viscosity(20.0)

--- a/scp/__init__.py
+++ b/scp/__init__.py
@@ -1,3 +1,18 @@
 import importlib.metadata
 
-VERSION = importlib.metadata.version("SecondaryCoolantProps")
+from scp.api import available_fluids, available_properties, get_fluid
+from scp.user_defined import UserDefinedFluid, UserDefinedProperties
+
+try:
+    VERSION = importlib.metadata.version("SecondaryCoolantProps")
+except importlib.metadata.PackageNotFoundError:
+    VERSION = "0+unknown"
+
+__all__ = [
+    "VERSION",
+    "UserDefinedFluid",
+    "UserDefinedProperties",
+    "available_fluids",
+    "available_properties",
+    "get_fluid",
+]

--- a/scp/api.py
+++ b/scp/api.py
@@ -18,21 +18,20 @@ _FLUID_FACTORIES: dict[str, FluidFactory] = {
     "methyl_alcohol": MethylAlcohol,
     "propylene_glycol": PropyleneGlycol,
 }
-_PROPERTY_NAMES = (
+_USER_DEFINED_REQUIRED_PROPERTY_KEYS = (
     "viscosity",
     "specific_heat",
     "density",
     "conductivity",
+)
+_PROPERTY_NAMES = (
+    *_USER_DEFINED_REQUIRED_PROPERTY_KEYS,
     "prandtl",
     "thermal_diffusivity",
     "freeze_point",
 )
-_USER_DEFINED_FLUID_KEY = "user_defined"
 _USER_DEFINED_PROPERTY_KEYS = (
-    "viscosity",
-    "specific_heat",
-    "density",
-    "conductivity",
+    *_USER_DEFINED_REQUIRED_PROPERTY_KEYS,
     "freeze_point",
 )
 
@@ -56,7 +55,7 @@ def available_fluids(*, include_user_defined: bool = True) -> tuple[str, ...]:
     """
     fluids = ("water", *_FLUID_FACTORIES.keys())
     if include_user_defined:
-        return (*fluids, _USER_DEFINED_FLUID_KEY)
+        return (*fluids, "user_defined")
     return fluids
 
 
@@ -114,7 +113,7 @@ def _collect_user_defined_options(
         raise ValueError(msg)
 
     missing_properties = [
-        prop_name for prop_name in _USER_DEFINED_PROPERTY_KEYS[:4] if prop_name not in property_values
+        prop_name for prop_name in _USER_DEFINED_REQUIRED_PROPERTY_KEYS if prop_name not in property_values
     ]
     if missing_properties:
         msg = f"User-defined fluid is missing required properties: {', '.join(missing_properties)}"
@@ -135,7 +134,7 @@ def _collect_user_defined_options(
 
 
 def get_fluid(
-    fluid: str | BaseFluid,
+    fluid: str,
     *,
     concentration: float = 0.0,
     properties: UserDefinedProperties | Mapping[str, object] | None = None,
@@ -144,20 +143,15 @@ def get_fluid(
     """
     Construct a fluid from the user-facing API.
 
-    @param fluid: Fluid key, or an existing BaseFluid instance
+    @param fluid: Fluid key
     @param concentration: Mixture concentration fraction for built-in mixture fluids
     @param properties: User-defined property values
     @param user_defined_options: User-defined fluid options and property values
     @return: Fluid instance
     """
-    if isinstance(fluid, BaseFluid):
-        if properties is not None or user_defined_options:
-            msg = "Existing fluid instances do not accept additional user-defined options"
-            raise ValueError(msg)
-        return fluid
 
     fluid_key = _normalize_key(fluid)
-    if (properties is not None or user_defined_options) and fluid_key != _USER_DEFINED_FLUID_KEY:
+    if (properties is not None or user_defined_options) and fluid_key != "user_defined":
         msg = "User-defined options can only be used with the user_defined fluid"
         raise ValueError(msg)
     if fluid_key == "water":
@@ -165,7 +159,7 @@ def get_fluid(
             msg = "Water does not accept a nonzero concentration"
             raise ValueError(msg)
         return Water()
-    if fluid_key == _USER_DEFINED_FLUID_KEY:
+    if fluid_key == "user_defined":
         user_properties, name, t_min, t_max = _collect_user_defined_options(properties, user_defined_options)
 
         return UserDefinedFluid(

--- a/scp/api.py
+++ b/scp/api.py
@@ -1,0 +1,181 @@
+from collections.abc import Callable, Mapping
+from numbers import Real
+from typing import cast
+
+from scp.base_fluid import BaseFluid
+from scp.ethyl_alcohol import EthylAlcohol
+from scp.ethylene_glycol import EthyleneGlycol
+from scp.methyl_alcohol import MethylAlcohol
+from scp.propylene_glycol import PropyleneGlycol
+from scp.user_defined import FreezingPointProperty, TemperatureProperty, UserDefinedFluid, UserDefinedProperties
+from scp.water import Water
+
+FluidFactory = Callable[[float], BaseFluid]
+
+_FLUID_FACTORIES: dict[str, FluidFactory] = {
+    "ethyl_alcohol": EthylAlcohol,
+    "ethylene_glycol": EthyleneGlycol,
+    "methyl_alcohol": MethylAlcohol,
+    "propylene_glycol": PropyleneGlycol,
+}
+_PROPERTY_NAMES = (
+    "viscosity",
+    "specific_heat",
+    "density",
+    "conductivity",
+    "prandtl",
+    "thermal_diffusivity",
+    "freeze_point",
+)
+_USER_DEFINED_FLUID_KEY = "user_defined"
+_USER_DEFINED_PROPERTY_KEYS = (
+    "viscosity",
+    "specific_heat",
+    "density",
+    "conductivity",
+    "freeze_point",
+)
+
+
+def _normalize_key(value: str) -> str:
+    """
+    Normalize a user-facing fluid or property key.
+
+    @param value: User-facing key
+    @return: Normalized key
+    """
+    return value.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def available_fluids(*, include_user_defined: bool = True) -> tuple[str, ...]:
+    """
+    Return the fluid keys accepted by :func:`get_fluid`.
+
+    @param include_user_defined: Include the key for user-defined fluids
+    @return: Supported fluid keys
+    """
+    fluids = ("water", *_FLUID_FACTORIES.keys())
+    if include_user_defined:
+        return (*fluids, _USER_DEFINED_FLUID_KEY)
+    return fluids
+
+
+def available_properties() -> tuple[str, ...]:
+    """
+    Return the property keys supported by fluid instances and the CLI.
+
+    @return: Supported property keys
+    """
+    return _PROPERTY_NAMES
+
+
+def _float_option(option_name: str, option_value: object) -> float:
+    """
+    Convert a user-defined fluid option to a float.
+
+    @param option_name: Option name for error messages
+    @param option_value: User-defined option value
+    @return: Float value
+    """
+    if isinstance(option_value, Real) and not isinstance(option_value, bool):
+        return float(option_value)
+
+    msg = f'User-defined option "{option_name}" must be a real number'
+    raise TypeError(msg)
+
+
+def _collect_user_defined_options(
+    properties: UserDefinedProperties | Mapping[str, object] | None,
+    options: dict[str, object],
+) -> tuple[UserDefinedProperties, str, float, float]:
+    """
+    Collect user-defined fluid options into a validated property object.
+
+    @param properties: User-defined properties object or mapping
+    @param options: Additional user-defined fluid options
+    @return: Properties, name, minimum temperature, and maximum temperature
+    """
+    name = str(options.pop("name", "UserDefinedFluid"))
+    t_min = _float_option("t_min", options.pop("t_min", -273.15))
+    t_max = _float_option("t_max", options.pop("t_max", 1000.0))
+
+    if isinstance(properties, UserDefinedProperties):
+        if options:
+            msg = f"Unexpected user-defined fluid options: {', '.join(sorted(options))}"
+            raise ValueError(msg)
+        return properties, name, t_min, t_max
+
+    property_values = dict(properties or {})
+    property_values.update(options)
+
+    unknown_properties = set(property_values).difference(_USER_DEFINED_PROPERTY_KEYS)
+    if unknown_properties:
+        msg = f"Unexpected user-defined fluid properties: {', '.join(sorted(unknown_properties))}"
+        raise ValueError(msg)
+
+    missing_properties = [
+        prop_name for prop_name in _USER_DEFINED_PROPERTY_KEYS[:4] if prop_name not in property_values
+    ]
+    if missing_properties:
+        msg = f"User-defined fluid is missing required properties: {', '.join(missing_properties)}"
+        raise ValueError(msg)
+
+    return (
+        UserDefinedProperties(
+            viscosity=cast(TemperatureProperty, property_values["viscosity"]),
+            specific_heat=cast(TemperatureProperty, property_values["specific_heat"]),
+            density=cast(TemperatureProperty, property_values["density"]),
+            conductivity=cast(TemperatureProperty, property_values["conductivity"]),
+            freeze_point=cast(FreezingPointProperty, property_values.get("freeze_point", 0.0)),
+        ),
+        name,
+        t_min,
+        t_max,
+    )
+
+
+def get_fluid(
+    fluid: str | BaseFluid,
+    *,
+    concentration: float = 0.0,
+    properties: UserDefinedProperties | Mapping[str, object] | None = None,
+    **user_defined_options: object,
+) -> BaseFluid:
+    """
+    Construct a fluid from the user-facing API.
+
+    @param fluid: Fluid key, or an existing BaseFluid instance
+    @param concentration: Mixture concentration fraction for built-in mixture fluids
+    @param properties: User-defined property values
+    @param user_defined_options: User-defined fluid options and property values
+    @return: Fluid instance
+    """
+    if isinstance(fluid, BaseFluid):
+        if properties is not None or user_defined_options:
+            msg = "Existing fluid instances do not accept additional user-defined options"
+            raise ValueError(msg)
+        return fluid
+
+    fluid_key = _normalize_key(fluid)
+    if (properties is not None or user_defined_options) and fluid_key != _USER_DEFINED_FLUID_KEY:
+        msg = "User-defined options can only be used with the user_defined fluid"
+        raise ValueError(msg)
+    if fluid_key == "water":
+        if concentration != 0.0:
+            msg = "Water does not accept a nonzero concentration"
+            raise ValueError(msg)
+        return Water()
+    if fluid_key == _USER_DEFINED_FLUID_KEY:
+        user_properties, name, t_min, t_max = _collect_user_defined_options(properties, user_defined_options)
+
+        return UserDefinedFluid(
+            user_properties,
+            name=name,
+            t_min=t_min,
+            t_max=t_max,
+        )
+    if fluid_key in _FLUID_FACTORIES:
+        return _FLUID_FACTORIES[fluid_key](concentration)
+
+    msg = f'Unsupported fluid "{fluid}". Supported fluids: {", ".join(available_fluids())}'
+    raise ValueError(msg)

--- a/scp/base_fluid.py
+++ b/scp/base_fluid.py
@@ -1,5 +1,6 @@
 import warnings
 from abc import ABC, abstractmethod
+from numbers import Real
 
 
 class BaseFluid(ABC):
@@ -31,8 +32,8 @@ class BaseFluid(ABC):
 
         self._set_temperature_limits(t_min, t_max)
 
-        if isinstance(x, float) and isinstance(x_min, float) and isinstance(x_max, float):
-            self._set_concentration_limits(x, x_min, x_max)
+        if isinstance(x, Real) and isinstance(x_min, Real) and isinstance(x_max, Real):
+            self._set_concentration_limits(float(x), float(x_min), float(x_max))
 
     @property
     @abstractmethod

--- a/scp/cli.py
+++ b/scp/cli.py
@@ -2,28 +2,12 @@ from sys import stderr
 
 import click
 
-from scp import ethyl_alcohol, ethylene_glycol, methyl_alcohol, propylene_glycol, water
+from scp.api import available_fluids, available_properties, get_fluid
 
 # Add this to .bashrc for nice completion: eval "$(_SCPROP_COMPLETE=bash_source scprop)"
 
-fluids = {
-    "water": water.Water,
-    "ethyl_alcohol": ethyl_alcohol.EthylAlcohol,
-    "ethylene_glycol": ethylene_glycol.EthyleneGlycol,
-    "methyl_alcohol": methyl_alcohol.MethylAlcohol,
-    "propylene_glycol": propylene_glycol.PropyleneGlycol,
-}
-fluid_options = click.Choice(list(fluids.keys()))
-properties = (
-    "viscosity",
-    "specific_heat",
-    "density",
-    "conductivity",
-    "prandtl",
-    "thermal_diffusivity",
-    "freeze_point",
-)
-prop_options = click.Choice(properties)
+fluid_options = click.Choice(available_fluids(include_user_defined=False))
+prop_options = click.Choice(available_properties())
 x_range = click.FloatRange(min=0.0, max=1.0)
 
 
@@ -79,10 +63,10 @@ def cli(fluid: str, concentration: float, fluid_prop: str, temperature: float, q
             file=stderr,
         )
     if fluid == "water" or concentration == 0.0:
-        f = water.Water()
+        f = get_fluid("water")
         fluid = "water"
     else:
-        f = fluids[fluid](concentration)
+        f = get_fluid(fluid, concentration=concentration)
 
     if fluid_prop == "freeze_point":
         value = getattr(f, fluid_prop)(concentration)

--- a/scp/user_defined.py
+++ b/scp/user_defined.py
@@ -1,0 +1,143 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from numbers import Real
+from typing import TypeAlias
+
+from scp.base_fluid import BaseFluid
+
+TemperatureProperty: TypeAlias = float | Callable[[float], float]
+FreezingPointProperty: TypeAlias = float | Callable[[float | None], float]
+
+
+@dataclass(frozen=True)
+class UserDefinedProperties:
+    """
+    Core user-defined fluid properties.
+    """
+
+    viscosity: TemperatureProperty
+    specific_heat: TemperatureProperty
+    density: TemperatureProperty
+    conductivity: TemperatureProperty
+    freeze_point: FreezingPointProperty = 0.0
+
+    def __post_init__(self) -> None:
+        for prop_name in ("viscosity", "specific_heat", "density", "conductivity"):
+            _validate_property_value(prop_name, getattr(self, prop_name))
+        _validate_property_value("freeze_point", self.freeze_point)
+
+
+def _validate_property_value(prop_name: str, prop_value: object) -> None:
+    """
+    Validate that a user-defined property can be evaluated later.
+
+    @param prop_name: Property name for error messages
+    @param prop_value: User-defined property value
+    """
+    if callable(prop_value):
+        return
+    if isinstance(prop_value, Real) and not isinstance(prop_value, bool):
+        return
+
+    msg = f'User-defined property "{prop_name}" must be a real number or callable'
+    raise TypeError(msg)
+
+
+class UserDefinedFluid(BaseFluid):
+    """
+    A fluid whose core properties are provided by the user.
+
+    Each temperature-dependent property may be supplied as either a constant
+    value or a callable that accepts temperature in Celsius and returns the
+    property value in the same units used by :class:`scp.base_fluid.BaseFluid`.
+    """
+
+    def __init__(
+        self,
+        properties: UserDefinedProperties,
+        *,
+        name: str = "UserDefinedFluid",
+        t_min: float = -273.15,
+        t_max: float = 1000.0,
+    ) -> None:
+        """
+        Construct a user-defined fluid.
+
+        @param properties: User-defined fluid property values
+        @param name: Descriptive fluid name
+        @param t_min: Minimum valid temperature in Celsius
+        @param t_max: Maximum valid temperature in Celsius
+        """
+
+        self._fluid_name = name
+        self._properties = properties
+        super().__init__(t_min, t_max)
+
+    @property
+    def fluid_name(self) -> str:
+        """
+        Returns the descriptive fluid name.
+
+        @return: Fluid name
+        """
+        return self._fluid_name
+
+    def _evaluate_temperature_property(self, prop: TemperatureProperty, temp: float) -> float:
+        """
+        Evaluate a constant or callable temperature-dependent property.
+
+        @param prop: Property value or function
+        @param temp: Fluid temperature in Celsius
+        @return: Evaluated property value
+        """
+        temp = self._check_temperature(temp)
+        if callable(prop):
+            return float(prop(temp))
+        return float(prop)
+
+    def viscosity(self, temp: float) -> float:
+        """
+        Returns the user-defined dynamic viscosity.
+
+        @param temp: Fluid temperature, in degrees Celsius
+        @return: Dynamic viscosity in [Pa-s]
+        """
+        return self._evaluate_temperature_property(self._properties.viscosity, temp)
+
+    def specific_heat(self, temp: float) -> float:
+        """
+        Returns the user-defined specific heat.
+
+        @param temp: Fluid temperature, in degrees Celsius
+        @return: Specific heat in [J/kg-K]
+        """
+        return self._evaluate_temperature_property(self._properties.specific_heat, temp)
+
+    def density(self, temp: float) -> float:
+        """
+        Returns the user-defined density.
+
+        @param temp: Fluid temperature, in degrees Celsius
+        @return: Density in [kg/m3]
+        """
+        return self._evaluate_temperature_property(self._properties.density, temp)
+
+    def conductivity(self, temp: float) -> float:
+        """
+        Returns the user-defined thermal conductivity.
+
+        @param temp: Fluid temperature, in degrees Celsius
+        @return: Thermal conductivity in [W/m-K]
+        """
+        return self._evaluate_temperature_property(self._properties.conductivity, temp)
+
+    def freeze_point(self, x: float | None = None) -> float:
+        """
+        Returns the user-defined freezing point.
+
+        @param x: Optional concentration fraction
+        @return: Freezing point temperature in Celsius
+        """
+        if callable(self._properties.freeze_point):
+            return float(self._properties.freeze_point(x))
+        return float(self._properties.freeze_point)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,12 +42,6 @@ def test_get_fluid_returns_built_in_fluid() -> None:
     assert pg.x == pytest.approx(0.4)
 
 
-def test_get_fluid_returns_existing_fluid_instance() -> None:
-    fluid = Water()
-
-    assert get_fluid(fluid) is fluid
-
-
 def test_get_fluid_returns_user_defined_fluid() -> None:
     fluid = get_fluid(
         "user defined",
@@ -103,9 +97,6 @@ def test_get_fluid_rejects_invalid_inputs() -> None:
 
     with pytest.raises(ValueError, match="User-defined options"):
         get_fluid("water", properties={"viscosity": 0.001})
-
-    with pytest.raises(ValueError, match="Existing fluid instances"):
-        get_fluid(Water(), properties={"viscosity": 0.001})
 
     with pytest.raises(ValueError, match="Unexpected user-defined fluid options"):
         get_fluid(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,161 @@
+import pytest
+
+from scp import UserDefinedProperties, available_fluids, available_properties, get_fluid
+from scp.propylene_glycol import PropyleneGlycol
+from scp.user_defined import UserDefinedFluid
+from scp.water import Water
+
+
+def test_available_fluids_includes_user_defined_by_default() -> None:
+    assert available_fluids() == (
+        "water",
+        "ethyl_alcohol",
+        "ethylene_glycol",
+        "methyl_alcohol",
+        "propylene_glycol",
+        "user_defined",
+    )
+    assert "user_defined" not in available_fluids(include_user_defined=False)
+
+
+def test_available_properties() -> None:
+    assert available_properties() == (
+        "viscosity",
+        "specific_heat",
+        "density",
+        "conductivity",
+        "prandtl",
+        "thermal_diffusivity",
+        "freeze_point",
+    )
+
+
+def test_get_fluid_returns_built_in_fluid() -> None:
+    assert isinstance(get_fluid("water"), Water)
+
+    pg_zero = get_fluid("propylene_glycol", concentration=0)
+    assert isinstance(pg_zero, PropyleneGlycol)
+    assert pg_zero.x == pytest.approx(0.0)
+
+    pg = get_fluid("propylene-glycol", concentration=0.4)
+    assert isinstance(pg, PropyleneGlycol)
+    assert pg.x == pytest.approx(0.4)
+
+
+def test_get_fluid_returns_existing_fluid_instance() -> None:
+    fluid = Water()
+
+    assert get_fluid(fluid) is fluid
+
+
+def test_get_fluid_returns_user_defined_fluid() -> None:
+    fluid = get_fluid(
+        "user defined",
+        name="CustomFluid",
+        viscosity=0.002,
+        specific_heat=3200.0,
+        density=1050.0,
+        conductivity=0.42,
+        freeze_point=-12.0,
+    )
+
+    assert isinstance(fluid, UserDefinedFluid)
+    assert fluid.fluid_name == "CustomFluid"
+    assert fluid.density(20.0) == pytest.approx(1050.0)
+
+    properties = UserDefinedProperties(
+        viscosity=0.003,
+        specific_heat=3100.0,
+        density=1040.0,
+        conductivity=0.4,
+    )
+    property_object_fluid = get_fluid("user_defined", properties=properties)
+
+    assert isinstance(property_object_fluid, UserDefinedFluid)
+    assert property_object_fluid.viscosity(20.0) == pytest.approx(0.003)
+
+
+def test_get_fluid_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError, match="Water does not accept"):
+        get_fluid("water", concentration=0.2)
+
+    with pytest.raises(ValueError, match="Unsupported fluid"):
+        get_fluid("unknown")
+
+    with pytest.raises(ValueError, match="missing required properties"):
+        get_fluid("user_defined", viscosity=0.001)
+
+    with pytest.raises(TypeError, match="viscosity"):
+        get_fluid("user_defined", viscosity=None, specific_heat=1.0, density=1.0, conductivity=1.0)
+
+    with pytest.raises(TypeError, match="t_min"):
+        get_fluid(
+            "user_defined",
+            viscosity=0.001,
+            specific_heat=1.0,
+            density=1.0,
+            conductivity=1.0,
+            t_min=None,
+        )
+
+    with pytest.raises(ValueError, match="User-defined options"):
+        get_fluid("water", viscosity=0.001)
+
+    with pytest.raises(ValueError, match="User-defined options"):
+        get_fluid("water", properties={"viscosity": 0.001})
+
+    with pytest.raises(ValueError, match="Existing fluid instances"):
+        get_fluid(Water(), properties={"viscosity": 0.001})
+
+    with pytest.raises(ValueError, match="Unexpected user-defined fluid options"):
+        get_fluid(
+            "user_defined",
+            properties=UserDefinedProperties(
+                viscosity=0.001,
+                specific_heat=3200.0,
+                density=1050.0,
+                conductivity=0.42,
+            ),
+            viscosity=0.002,
+        )
+
+    with pytest.raises(ValueError, match="Unexpected user-defined fluid properties"):
+        get_fluid(
+            "user_defined",
+            properties={
+                "viscosity": 0.001,
+                "specific_heat": 3200.0,
+                "density": 1050.0,
+                "conductivity": 0.42,
+                "enthalpy": 100.0,
+            },
+        )
+
+
+def test_get_fluid_returns_instances_for_property_evaluation() -> None:
+    water = get_fluid("water")
+    pg = get_fluid("propylene glycol", concentration=0.4)
+    fluid = UserDefinedFluid(
+        UserDefinedProperties(
+            viscosity=0.002,
+            specific_heat=3200.0,
+            density=lambda temp: 1000.0 - temp,
+            conductivity=0.42,
+        ),
+    )
+
+    assert water.density(25.0) == pytest.approx(Water().density(25.0))
+    assert pg.freeze_point(0.4) == pytest.approx(PropyleneGlycol(0.4).freeze_point(0.4))
+    assert fluid.density(30.0) == pytest.approx(970.0)
+
+
+def test_get_fluid_accepts_user_defined_properties_for_derived_properties() -> None:
+    fluid = get_fluid(
+        "user_defined",
+        viscosity=0.002,
+        specific_heat=3200.0,
+        density=1050.0,
+        conductivity=0.42,
+    )
+
+    assert fluid.thermal_diffusivity(20.0) == pytest.approx(1.25e-7)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,103 @@
+from io import StringIO
+
+import pytest
+from click.testing import CliRunner
+
+import scp.cli
+from scp.cli import cli
+from scp.water import Water
+
+
+def test_cli_reports_verbose_property_output() -> None:
+    result = CliRunner().invoke(cli, ["--fluid", "water", "--property", "density", "--temperature", "25"])
+
+    assert result.exit_code == 0
+    assert "Fluid:    water" in result.output
+    assert "Property: density" in result.output
+    assert "Units:    [kg/m3]" in result.output
+
+
+def test_cli_reports_quick_property_output() -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--fluid",
+            "propylene_glycol",
+            "--concentration",
+            "0.4",
+            "--property",
+            "density",
+            "--temperature",
+            "20",
+            "--quick",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert float(result.output) == pytest.approx(1032.3, rel=0.001)
+
+
+def test_cli_uses_freeze_point_concentration() -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--fluid",
+            "propylene_glycol",
+            "--concentration",
+            "0.4",
+            "--property",
+            "freeze_point",
+            "--temperature",
+            "20",
+            "--quick",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert float(result.output) == pytest.approx(-20.568, abs=0.01)
+
+
+def test_cli_zero_mixture_concentration_uses_water(monkeypatch) -> None:
+    stderr = StringIO()
+    monkeypatch.setattr(scp.cli, "stderr", stderr)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--fluid",
+            "propylene_glycol",
+            "--property",
+            "density",
+            "--temperature",
+            "25",
+            "--quick",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Mixture requested, but concentration zero" in stderr.getvalue()
+    assert float(result.output) == pytest.approx(Water().density(25.0))
+
+
+def test_cli_nonzero_water_concentration_uses_water(monkeypatch) -> None:
+    stderr = StringIO()
+    monkeypatch.setattr(scp.cli, "stderr", stderr)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--fluid",
+            "water",
+            "--concentration",
+            "0.4",
+            "--property",
+            "density",
+            "--temperature",
+            "25",
+            "--quick",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Pure water requested, but nonzero concentration entered" in stderr.getvalue()
+    assert float(result.output) == pytest.approx(Water().density(25.0))

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,17 @@
+import importlib
+import importlib.metadata
+
+import scp
+
+
+def test_version_falls_back_when_package_metadata_is_unavailable(monkeypatch) -> None:
+    def raise_package_not_found(_distribution_name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(importlib.metadata, "version", raise_package_not_found)
+
+    try:
+        assert importlib.reload(scp).VERSION == "0+unknown"
+    finally:
+        monkeypatch.undo()
+        importlib.reload(scp)

--- a/tests/test_propylene_glycol.py
+++ b/tests/test_propylene_glycol.py
@@ -57,8 +57,32 @@ def test_freeze_point(pg: float, freeze_point: float) -> None:
     assert PropyleneGlycol(pg).freeze_point(pg) == pytest.approx(freeze_point, abs=0.01)
 
 
+def test_integer_concentration_is_supported() -> None:
+    pg = PropyleneGlycol(0)
+
+    assert pg.x == pytest.approx(0.0)
+    assert pg.density(20) == pytest.approx(9.9852e02, rel=0.001)
+
+
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_out_of_range_temps() -> None:
     pg = PropyleneGlycol(0.4)
     assert pg.density(-50) == pytest.approx(pg.density(pg.t_min), abs=0.01)
     assert pg.density(150) == pytest.approx(pg.density(pg.t_max), abs=0.01)
+
+
+def test_missing_base_values_raise_errors() -> None:
+    pg = PropyleneGlycol(0.4)
+
+    pg.x_base = None
+    with pytest.raises(ValueError, match="x_base is not set"):
+        pg._f_prop((), 20.0)
+    with pytest.raises(ValueError, match="x_base is not set"):
+        pg._f_prop_t_freeze((), 0.4)
+
+    pg.x_base = 30.0
+    pg.t_base = None
+    with pytest.raises(ValueError, match="t_base is not set"):
+        pg._f_prop((), 20.0)
+    with pytest.raises(ValueError, match="t_base is not set"):
+        pg._f_prop_t_freeze((), 0.4)

--- a/tests/test_user_defined.py
+++ b/tests/test_user_defined.py
@@ -1,0 +1,112 @@
+import pytest
+
+from scp.user_defined import UserDefinedFluid, UserDefinedProperties
+
+
+def make_user_defined_fluid(**kwargs) -> UserDefinedFluid:
+    properties = UserDefinedProperties(
+        viscosity=kwargs.pop("viscosity", 0.002),
+        specific_heat=kwargs.pop("specific_heat", 3200.0),
+        density=kwargs.pop("density", 1050.0),
+        conductivity=kwargs.pop("conductivity", 0.42),
+        freeze_point=kwargs.pop("freeze_point", -12.0),
+    )
+    return UserDefinedFluid(properties, **kwargs)
+
+
+def test_user_defined_fluid_accepts_constant_properties() -> None:
+    fluid = make_user_defined_fluid(
+        name="TestFluid",
+        t_min=-20.0,
+        t_max=80.0,
+    )
+
+    assert fluid.fluid_name == "TestFluid"
+    assert fluid.viscosity(20.0) == pytest.approx(0.002)
+    assert fluid.specific_heat(20.0) == pytest.approx(3200.0)
+    assert fluid.density(20.0) == pytest.approx(1050.0)
+    assert fluid.conductivity(20.0) == pytest.approx(0.42)
+    assert fluid.freeze_point() == pytest.approx(-12.0)
+    assert fluid.mu(20.0) == pytest.approx(0.002)
+    assert fluid.cp(20.0) == pytest.approx(3200.0)
+    assert fluid.rho(20.0) == pytest.approx(1050.0)
+    assert fluid.k(20.0) == pytest.approx(0.42)
+    assert fluid.prandtl(20.0) == pytest.approx(15.238095238)
+    assert fluid.pr(20.0) == pytest.approx(15.238095238)
+    assert fluid.thermal_diffusivity(20.0) == pytest.approx(1.25e-7)
+    assert fluid.alpha(20.0) == pytest.approx(1.25e-7)
+
+
+def test_user_defined_fluid_accepts_callable_properties() -> None:
+    fluid = UserDefinedFluid(
+        UserDefinedProperties(
+            viscosity=lambda temp: 0.003 - 1.0e-5 * temp,
+            specific_heat=lambda temp: 3000.0 + 2.0 * temp,
+            density=lambda temp: 1000.0 - 0.5 * temp,
+            conductivity=lambda temp: 0.3 + 1.0e-3 * temp,
+            freeze_point=lambda x: -30.0 * x,
+        ),
+    )
+
+    assert fluid.viscosity(10.0) == pytest.approx(0.0029)
+    assert fluid.specific_heat(10.0) == pytest.approx(3020.0)
+    assert fluid.density(10.0) == pytest.approx(995.0)
+    assert fluid.conductivity(10.0) == pytest.approx(0.31)
+    assert fluid.freeze_point(0.4) == pytest.approx(-12.0)
+
+
+def test_user_defined_properties_reject_invalid_values() -> None:
+    with pytest.raises(TypeError, match="viscosity"):
+        UserDefinedProperties(
+            viscosity=None,
+            specific_heat=3000.0,
+            density=1000.0,
+            conductivity=0.3,
+        )
+
+    with pytest.raises(TypeError, match="freeze_point"):
+        UserDefinedProperties(
+            viscosity=0.002,
+            specific_heat=3000.0,
+            density=1000.0,
+            conductivity=0.3,
+            freeze_point=None,
+        )
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_user_defined_fluid_checks_temperature_limits() -> None:
+    fluid = make_user_defined_fluid(
+        viscosity=lambda temp: temp,
+        specific_heat=1.0,
+        density=1.0,
+        conductivity=1.0,
+        t_min=0.0,
+        t_max=10.0,
+    )
+
+    assert fluid.viscosity(-10.0) == pytest.approx(0.0)
+    assert fluid.viscosity(20.0) == pytest.approx(10.0)
+
+
+def test_user_defined_fluid_rejects_invalid_temperature_limits() -> None:
+    with pytest.raises(ValueError, match="t_min is greater than t_max"):
+        make_user_defined_fluid(t_min=10.0, t_max=10.0)
+
+
+def test_user_defined_fluid_rejects_invalid_concentration_limits() -> None:
+    fluid = make_user_defined_fluid()
+
+    with pytest.raises(ValueError, match="x_min is greater than x_max"):
+        fluid._set_concentration_limits(0.5, 0.6, 0.4)
+
+
+def test_user_defined_fluid_checks_concentration_limits() -> None:
+    fluid = make_user_defined_fluid()
+    fluid._set_concentration_limits(0.5, 0.2, 0.8)
+
+    with pytest.warns(UserWarning, match="concentration must be greater"):
+        assert fluid._check_concentration(0.1) == pytest.approx(0.2)
+
+    with pytest.warns(UserWarning, match="concentration must be less"):
+        assert fluid._check_concentration(0.9) == pytest.approx(0.8)

--- a/tests/test_user_defined.py
+++ b/tests/test_user_defined.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import pytest
 
 from scp.user_defined import UserDefinedFluid, UserDefinedProperties
@@ -44,7 +46,7 @@ def test_user_defined_fluid_accepts_callable_properties() -> None:
             specific_heat=lambda temp: 3000.0 + 2.0 * temp,
             density=lambda temp: 1000.0 - 0.5 * temp,
             conductivity=lambda temp: 0.3 + 1.0e-3 * temp,
-            freeze_point=lambda x: -30.0 * x,
+            freeze_point=lambda temp: -30.0 * (temp or 0.0),
         ),
     )
 
@@ -58,7 +60,7 @@ def test_user_defined_fluid_accepts_callable_properties() -> None:
 def test_user_defined_properties_reject_invalid_values() -> None:
     with pytest.raises(TypeError, match="viscosity"):
         UserDefinedProperties(
-            viscosity=None,
+            viscosity=cast(Any, None),
             specific_heat=3000.0,
             density=1000.0,
             conductivity=0.3,
@@ -70,7 +72,7 @@ def test_user_defined_properties_reject_invalid_values() -> None:
             specific_heat=3000.0,
             density=1000.0,
             conductivity=0.3,
-            freeze_point=None,
+            freeze_point=cast(Any, None),
         )
 
 

--- a/tests/test_water.py
+++ b/tests/test_water.py
@@ -27,6 +27,22 @@ def test_viscosity(water: Water, temp_c: float, expected: float) -> None:
     assert water.viscosity(temp_c) == pytest.approx(expected, rel=0.01)
 
 
+def test_viscosity_above_normal_boiling_range(water: Water) -> None:
+    water.t_max = 120.0
+
+    assert water.viscosity(110.0) == pytest.approx(0.000255, rel=0.01)
+
+
+def test_property_units_are_defined_on_fluid_instances(water: Water) -> None:
+    assert water.viscosity_units() == "Pa-s"
+    assert water.specific_heat_units() == "J/kg-K"
+    assert water.density_units() == "kg/m3"
+    assert water.conductivity_units() == "W/m-K"
+    assert water.prandtl_units() == "-"
+    assert water.thermal_diffusivity_units() == "m2/s"
+    assert water.freeze_point_units() == "C"
+
+
 @pytest.mark.parametrize(
     ("temp_c", "expected"),
     [


### PR DESCRIPTION
PR is composed of two new features:

- Adds a new `get_fluid` API so users don't need to import all the various fluid classes individually.
- Adds a new user-defined fluid class that accepts constant or callable properties. Example below:

```python
custom_fluid = get_fluid(
    "user_defined",
    name="CustomFluid",
    viscosity=lambda temp: 0.003 - 1.0e-5 * temp,
    specific_heat=3200.0,
    density=lambda temp: 1000.0 - 0.5 * temp,
    conductivity=0.42,
    freeze_point=-12.0,
    t_min=-20.0,
    t_max=80.0,
)
```